### PR TITLE
First Changes for FTX Kanyon

### DIFF
--- a/Adjustments.h
+++ b/Adjustments.h
@@ -31,7 +31,7 @@ Motor: 540 size, 35 turns, stock pinion
 // ---------------------------------------------------------------------------------------------------------------------
 // Choose the receiver communication mode (never uncomment more than one! If all commented out = classic PWM RC signal communication)--
 // SBUS communication --------
-#define SBUS_COMMUNICATION // control signals are coming in via the SBUS interface (comment it out for classic RC signals)
+//#define SBUS_COMMUNICATION // control signals are coming in via the SBUS interface (comment it out for classic RC signals)
 boolean sbusInverted = true; // false = wired to NPN transistor signal inverter or uninverted SBUS signal (for example from "Micro RC" receiver)
 
 // Serial communication --------
@@ -45,7 +45,7 @@ boolean sbusInverted = true; // false = wired to NPN transistor signal inverter 
 
 // Sound files (22'050 Hz, 8 bit PCM recommended) -----------------------------------------------------------------------
 // Choose the start sound (uncomment the one you want) --------
-volatile int startVolumePercentage = 100; // Adjust the start volume (usually = 100%)
+volatile int startVolumePercentage = 90; // Adjust the start volume (usually = 100%)
 //#include "sounds/UnionPacific2002Start.h" // Union Pacific 2002 SD70M Locomotive Start
 //#include "sounds/ScaniaV8Start.h" // Scania V8 Start
 //#include "sounds/ScaniaR500V8Start.h" // Scania R500 V8 Start
@@ -57,18 +57,18 @@ volatile int startVolumePercentage = 100; // Adjust the start volume (usually = 
 //#include "sounds/KenworthW900Start.h" // Kenworth W900 Truck Start
 //#include "sounds/MackStart.h" // Mack Truck Start
 //#include "sounds/DetroitDieselStart.h" // Detroit Diesel generic Truck Start
-#include "sounds/InternationalDT-466Start.h" // International DT-466 Start
+//#include "sounds/InternationalDT-466Start.h" // International DT-466 Start
 //#include "sounds/Cat3406BStart.h" // Caterpillar 3406B start
 //#include "sounds/ActrosV8Start.h" // MB Actros V8 Truck Start
 //#include "sounds/VWBeetleStart.h" // VW Beetle or Bug
 //#include "sounds/HarleyDavidsonFXSBStart.h" // Harley Davidson FXSB start
 //#include "sounds/v8soundteststart.h" // Wombii's Scania V8 Fire Truck start
 //#include "sounds/JeepGrandCherokeeTrackhawkStart.h" // Jeep Grand Cherokee Trackhawk start
-//#include "sounds/carCranking.h" // Generic car cranking
+#include "sounds/carCranking.h" // Generic car cranking
 
 // Choose the motor idle sound (uncomment the one you want) --------
-volatile int idleVolumePercentage = 80; // Adjust the idle volume (usually = 100%, more also working, depending on sound, 50 - 60% if additional diesel knock sound is used)
-volatile int engineIdleVolumePercentage = 100; // the engine volume will be throttle dependent (usually = 40%, never more than 100%!)
+volatile int idleVolumePercentage = 100; // Adjust the idle volume (usually = 100%, more also working, depending on sound, 50 - 60% if additional diesel knock sound is used)
+volatile int engineIdleVolumePercentage = 40; // the engine volume will be throttle dependent (usually = 40%, never more than 100%!)
 //#include "sounds/20Hz.h" // 20Hz test tone
 //#include "sounds/100Hz.h" // 100Hz test tone
 //#include "sounds/1000Hz.h" // 1000Hz test tone
@@ -87,7 +87,7 @@ volatile int engineIdleVolumePercentage = 100; // the engine volume will be thro
 //#include "sounds/DetroitDieselIdle.h" // Detroit Diesel generic Truck (Volume 80%, 30%, Turbo 60%, 10%, Wastegate 50%, 1%, CEP 100, TSM 3)
 //#include "sounds/DetroitDieselStraightPipeIdle.h" // Detroit Diesel Truck with straight pipes (use multiplier = 2, acc = 2, dec = 1)
 //#include "sounds/DetroitDieselBassBoost15db.h" // Detroit Diesel Truck with straight pipes. Bass 100-200Hz + 15dB
-//#include "sounds/DetroitDieselBassBoost7db.h" // Detroit Diesel Truck with straight pipes. Bass 100-200Hz + 7dB (use it for King Hauler, Volume 60%, 40%, Turbo 60%, 10, Wastegate 100%, 1%, CEP 100, TSM 3, Knock volume 400, 10%, interval 2, 50)
+//#include "sounds/DetroitDieselBassBoost7db.h" // Detroit Diesel Truck with straight pipes. Bass 100-200Hz + 7dB (use it for King Hauler, Volume 55%, 40%, Turbo 60%, 10, Wastegate 100%, 1%, CEP 100, TSM 2, Knock volume 400, 10%, interval 1, 50)
 //#include "sounds/DetroitDieselPeterbiltCabover.h" // Detroit Diesel Peterbilt cabover truck
 //#include "sounds/DetroitDieselKenworth.h" // Detroit Diesel Kenworth truck (use Ural V8 Start & 100% turbo)
 //#include "sounds/DetroitDieselJohnDeereTractor.h" // Detroit Diesel John Deere tractor
@@ -97,12 +97,12 @@ volatile int engineIdleVolumePercentage = 100; // the engine volume will be thro
 //#include "sounds/M35BassBoost7db.h" // AM General M35 Truck Bass 100-200Hz + 7dB (Volume 100%, 35%, Turbo 100%, 30%)
 //#include "sounds/UnimogU1000TurboFullLoad.h" // Unimog U1000 Turbo (Volume 100%, 35%, Turbo 50%, 10%, Wastegate 150%, 1%)
 //#include "sounds/ActrosV8Idle.h" // MB Actros V8 Truck Idle (very noisy)
-//#include "sounds/ActrosLoggingTruckIdling.h" // Actros logging truck (Volume 80%, 40%, Turbo 60%, 10, Wastegate 100%, 1%, CEP 100, TSM 2, Knock volume 200, 10%, interval 4, 50)
-//#include "sounds/ActrosLoggingTruckIdling2.h" // Actros logging truck (Volume 50%, 100%, Turbo 10%, 10, Wastegate 100%, 1%, CEP 100, TSM 3, Knock volume 500, 10%, interval 2, 50, ActrosLoggingTruckDieselKnock3.h)
+//#include "sounds/ActrosLoggingTruckIdling.h" // Actros logging truck
 //#include "sounds/KenworthW900Idle.h" // Kenworth W900 Truck Idle (Volume 80%, 30%, Turbo 60%, 10%, Wastegate 50%, 1%, CEP 100, TSM 2)
 //#include "sounds/MackIdle.h" // Mack Truck Idle (very thin)
+//#include "sounds/ActrosLoggingTruckIdling.h" // Actros logging truck (Volume 80%, 40%, Turbo 60%, 10, Wastegate 100%, 1%, CEP 100, TSM 2, Knock volume 200, 10%, interval 4, 50)
 //#include "sounds/Tatra813Idle.h" // Tatra 813 8x8 air cooled V12 Diesel (Volume 80%, 50%, Turbo 0%, 0, Fan 250, 0, 250, No Wastegate, CEP 100, TSM 2, Knock volume 500, 0%, interval 2, 50)
-//#include "sounds/DefenderV8Idle.h" // Land Rover Defender V8 (Volume 100%, 40%, Turbo 0%, 0, Fan 0, 0, 250, No Wastegate, CEP 100, TSM 2, Knock volume 500, 0%, interval 2, 50, automatic = true)
+#include "sounds/DefenderV8Idle.h" // Land Rover Defender V8 (Volume 100%, 40%, Turbo 0%, 0, Fan 0, 0, 250, No Wastegate, CEP 100, TSM 2, Knock volume 500, 0%, interval 2, 50, automatic = true)
 //#include "sounds/Mustang68Idle.h" // Ford Mustang 1968
 //#include "sounds/DodgeChallenger70Idle.h" // 1970 Dodge Challenger
 //#include "sounds/MgBGtV8Idle.h" // MG B GT V8
@@ -114,8 +114,7 @@ volatile int engineIdleVolumePercentage = 100; // the engine volume will be thro
 //#include "sounds/HarleyDavidsonFXSBIdle.h" // Harley Davidson FXSB (Volume 60%, 40%, Turbo 0%, 10,  no Wastegate 100%, CEP 300, TSM 4, Knock volume 300, 10%, interval 2, 50)
 //#include "sounds/v8soundtestidle.h" // Wombii's Scania V8 Fire Truck (Volume 90%, 50%, Turbo 20%, 10, Wastegate 90%, 1%, CEP 100, TSM 3, Knock volume 350, 15%, interval 4, 10, ScaniaDieselKnock.h)
 //#include "sounds/JeepGrandCherokeeTrackhawkIdle.h" // Jeep Grand Cherokee Trackhawk idle (speaker with good bass required)
-#include "sounds/DAFXFIdle.h" // DAF XF truck (use International DT 466 start, ADAPTIVE_KNOCK_VOLUME, dieselKnockInterval = 3, dieselKnockAdaptiveVolumePercentage = 60)
-
+//#include "sounds/DAFXFIdle.h" // DAF XF truck
 
 // Choose the motor revving sound (experimental, uncomment the one you want) --------
 //#define REV_SOUND // uncomment this, if you want to use the separate, optional rev sound
@@ -131,21 +130,19 @@ const uint8_t revSwitchPoint = 250; // The rev sound is played instead of the id
 // play around here, the results are amazing, if you hit the right combination with the idle sound!) --------
 volatile int dieselKnockVolumePercentage = 500; // Adjust the Diesel knock volume (usually = 200 - 600%)
 volatile int dieselKnockIdleVolumePercentage = 0; // Diesel knock volume while idling (usually = 20%)
-volatile int dieselKnockInterval = 3; // Idle sample length divided by this number (1 - 20, depending on sound files)
-volatile int dieselKnockStartPoint = 20; // Volume will raise above this point ( usually 0, for "open pipe" exhaust about 250)
-#define ADAPTIVE_KNOCK_VOLUME // Experimental setting: only the first knock per engine cycle will be full volume!
-volatile int dieselKnockAdaptiveVolumePercentage = 60; // Adjust the Diesel knock volume for the non-first knocks per engine cycle (usually = 50%)
-//#include "sounds/DieselKnockDummy.h" // If you don't want Diesel knock sound
+volatile int dieselKnockInterval = 2; // Idle sample length divided by this number (1 - 20, depending on sound files)
+volatile int dieselKnockStartPoint = 50; // Volume will raise above this point ( usually 0, for "open pipe" exhaust about 250)
+//#define ADAPTIVE_KNOCK_VOLUME // Experimental setting: only the first knock per engine cycle will be full volume!
+volatile int dieselKnockAdaptiveVolumePercentage = 50; // Adjust the Diesel knock volume for the non-first knocks per engine cycle (usually = 50%)
+#include "sounds/DieselKnockDummy.h" // If you don't want Diesel knock sound
 //#include "sounds/ScaniaR620UphillKnock.h" // Scania R620 V8 (use it for King Hauler)
 //#include "sounds/LanzBulldogDieselKnock.h" // Lanz Bulldog tractor (Interval = 2)
-//#include "sounds/ScaniaDieselKnock.h" // Strong Scania V8 diesel knock while highway race against Volvo truck (500%, 10%, Interval = 2 possible, for slow running V8 engines)
-//#include "sounds/ScaniaDieselKnock2.h" // Strong, short Scania V8 diesel knock while highway race against Volvo truck (Interval = 4 possible, for faster running engines)
+//#include "sounds/ScaniaDieselKnock.h" // Strong Scania V8 diesel knock while highwyway race against Volvo truck (500%, 10%, Interval = 2 possible, for slow running V8 engines)
+//#include "sounds/ScaniaDieselKnock2.h" // Strong, short Scania V8 diesel knock while highwyway race against Volvo truck (Interval = 4 possible, for faster running engines)
 //#include "sounds/ScanıaR730V8DieselKnockShort.h" // Hard knock (400%, 0%, Interval = up to 8 possible, for small engines)
 //#include "sounds/ScanıaR730V8DieselKnockSlow.h" // Soft knock (500%, 10%, Interval = up to 4 possible, for meduim engines and Scania open pipe (interval = 1))
 //#include "sounds/SCANIAV850TonKnock.h" // 50 ton SCANIA knock
 //#include "sounds/ActrosLoggingTruckDieselKnock.h" // Actros logging truck
-//#include "sounds/ActrosLoggingTruckDieselKnock2.h" // Actros logging truck
-//#include "sounds/ActrosLoggingTruckDieselKnock3.h" // Actros logging truck (same as idle, for testing)
 //#include "sounds/Tatra813Knock.h" // Tatra 813 8x8 air cooled V12 Diesel
 //#include "sounds/Tatra813Roar.h" // Tatra 813 8x8 air cooled V12 Diesel (use this for 813)
 //#include "sounds/Tatra813RoarShort.h" // Tatra 813 8x8 air cooled V12 Diesel
@@ -154,20 +151,21 @@ volatile int dieselKnockAdaptiveVolumePercentage = 60; // Adjust the Diesel knoc
 //#include "sounds/DefenderV8Knock2.h" // Land Rover Defender V8 knock (experimental, don't use it)
 //#include "sounds/DefenderV8Knock3.h" // Land Rover Defender V8 knock (experimental, don't use it)
 //#include "sounds/DefenderV8Knock4.h" // Land Rover Defender V8 knock (experimental, don't use it)
+//#include "sounds/V8TrophyTruckKnock.h" // V8 Trophy Truck
 //#include "sounds/chevyNovaV8Knock.h" // Chevy Nova Coupe 1975
 //#include "sounds/JeepGrandCherokeeTrackhawkKnock.h" // Jeep Grand Cherokee Trackhawk knock
-#include "sounds/DAFXFKnock.h" // DAF XF truck
+//#include "sounds/DAFXFKnock.h" // DAF XF truck
 
 // Adjust the additional turbo sound (set "turboVolumePercentage" to "0", if you don't want it) --------
-volatile int turboVolumePercentage = 40; // Adjust the turbo volume (usually = 70%)
-volatile int turboIdleVolumePercentage = 10; // the turbo volume will be engine rpm dependent (usually = 10%)
+volatile int turboVolumePercentage = 0; // Adjust the turbo volume (usually = 70%)
+volatile int turboIdleVolumePercentage = 0; // the turbo volume will be engine rpm dependent (usually = 10%)
 #include "sounds/TurboWhistle.h" // Turbo sound, playing in parallel with engine sound!
 
 // Adjust the additional turbo wastegate  / blowoff valve  sound (set "wastegateVolumePercentage" to "0", if you don't want it)--------
-volatile int wastegateVolumePercentage = 90; // Adjust the wastegate volume (usually = 70%, up to 250%)
+volatile int wastegateVolumePercentage = 10; // Adjust the wastegate volume (usually = 70%, up to 250%)
 volatile int wastegateIdleVolumePercentage = 1; // Wastegate sound is played, after rapid throttle drop with engaged clutch
-//#include "sounds/WastegateDummy.h"
-#include "sounds/UnimogU1000TurboWastegate.h"
+#include "sounds/WastegateDummy.h"
+//#include "sounds/UnimogU1000TurboWastegate.h"
 //#include "sounds/ScanıaR730V8TurboWastegate.h"
 
 // Adjust the additional cooling fan sound (set "fanVolumePercentage" to "0", if you don't want it) --------
@@ -183,16 +181,16 @@ volatile int hornVolumePercentage = 100; // Adjust the horn volume (usually = 10
 //#include "sounds/TrainHorn.h" // American train horn
 //#include "sounds/HornblastersOUTLAWTrainHornLong.h" // Hornblasters outlaw train horn long
 //#include "sounds/HornblastersOUTLAWTrainHornShort.h" // Hornblasters outlaw train horn short
-#include "sounds/ManTgeHorn.h" // MAN TGE truck horn (King Hauler)
+//#include "sounds/ManTgeHorn.h" // MAN TGE truck horn (King Hauler)
 //#include "sounds/westinghouseHorn.h" // American truck horn (the best)
 //#include "sounds/FireTruckAirHorn.h" // US fire truck air horn
-//#include "sounds/CarHorn.h" // A boring car horn
+#include "sounds/CarHorn.h" // A boring car horn
 //#include "sounds/TruckHorn.h" // A generic truck horn
 //#include "sounds/PeterbiltHorn.h" // A Peterbilt truck horn
 //#include "sounds/2ToneTruckHorn.h" // A 2 tone truck horn
 
 // Choose the siren / additional horn sound (uncomment the one you want) --------
-volatile int sirenVolumePercentage = 120; // Adjust the siren volume (usually = 100%)
+volatile int sirenVolumePercentage = 100; // Adjust the siren volume (usually = 100%)
 #include "sounds/sirenDummy.h" // If you don't want siren sound
 //#include "sounds/UsPoliceSiren.h" // US Police siren
 //#include "sounds/FireTruckAirSiren.h" // US fire truck air siren (King Hauler)
@@ -202,17 +200,17 @@ volatile int sirenVolumePercentage = 120; // Adjust the siren volume (usually = 
 //#include "sounds/PostAutoHorn.h" // The typical Swiss post bus horn
 
 // Choose the air brake release sound (uncomment the one you want) --------
-volatile int brakeVolumePercentage = 150; // Adjust the brake volume (usually = 200%)
-//#include "sounds/AirBrakeDummy.h" // If you don't want air brake sound
+volatile int brakeVolumePercentage = 200; // Adjust the brake volume (usually = 200%)
+#include "sounds/AirBrakeDummy.h" // If you don't want air brake sound
 //#include "sounds/TruckAirBrakes.h" // Short truck air brake sound
 //#include "sounds/TruckAirBrakesLong.h" // Long truck air brake sound
-#include "sounds/TruckAirBrakes2.h" // Another truck air brake sound
+//#include "sounds/TruckAirBrakes2.h" // Another truck air brake sound
 //#include "sounds/AirBrakeSqueak.h" // Squeaky air brake sound
 
 // Choose the parking brake engaging sound (uncomment the one you want) --------
-volatile int parkingBrakeVolumePercentage = 150; // Adjust the brake volume (usually = 200%)
-//#include "sounds/ParkingBrakeDummy.h" // If you don't want parking brake sound
-#include "sounds/ParkingBrake.h" // Parking brake sound
+volatile int parkingBrakeVolumePercentage = 200; // Adjust the brake volume (usually = 200%)
+#include "sounds/ParkingBrakeDummy.h" // If you don't want parking brake sound
+//#include "sounds/ParkingBrake.h" // Parking brake sound
 
 // Choose the gear shifting sound (uncomment the one you want) --------
 volatile int shiftingVolumePercentage = 200; // Adjust the shifting volume (usually = 200%)
@@ -229,11 +227,11 @@ volatile int sound1VolumePercentage = 100; // Adjust the sound1 volume (usually 
 #include "sounds/door.h" // opening and closing the door
 
 // Choose the reversing beep sound --------
-volatile int reversingVolumePercentage = 70; // Adjust the reversing sound volume (usually = 70%)
+volatile int reversingVolumePercentage = 0; // Adjust the reversing sound volume (usually = 70%)
 #include "sounds/TruckReversingBeep.h" // 1000Hz peep sound
 
 // Choose the indicator / turn signal options --------
-const boolean indicators = true; // "true", if you want to trigger indicator lights (turn signals)
+const boolean indicators = false; // "true", if you want to trigger indicator lights (turn signals)
 volatile int indicatorVolumePercentage = 100; // Adjust the indicator sound volume (usually = 100%)
 const uint16_t indicatorOn = 300; // The indicator will be switched on above +/- this value, if wheels are turned
 const boolean INDICATOR_DIR = true; // adjust indicator direction with true or false
@@ -244,12 +242,12 @@ const boolean doubleFlashBlueLight = true; // double flash blue lights if "true"
 
 // PWM input signal range calibration ------------------------------------------------------------------------------------
 const uint16_t pulseNeutral = 30; // pulseZero +/- this value (30) is the neutral range
-const uint16_t pulseSpan = 490; // pulseZero +/- this value (max. 500 or less depending on remote signal range)
+const uint16_t pulseSpan = 450; // pulseZero +/- this value (150 for JMT 10A ESC, otherwise around 450)
 
 // PWM ESC output signal range calibration (connect crawler type ESC to pin 33)-------------------------------------------
-const int16_t escPulseSpan = 1200; // pulseZero +/- this value (> 500 = limited top speed, about 1000 for King Hauler, 1400 = 100km/h with 35T motor)
+const int16_t escPulseSpan = 1000; // pulseZero +/- this value (> 500 = limited top speed, about 1600 (new ESC = 1000) for King Hauler)
 const uint8_t escRampTimeFirstGear = 20; // determines, how fast the acceleration and deceleration happens (about 15 - 25, 20 for King Hauler)
-const uint8_t escRampTimeSecondGear = 50; // 50 for King Hauler (this value is always in use for automatic transmission, about 80)
+const uint8_t escRampTimeSecondGear = 80; // 50 for King Hauler (this value is always in use for automatic transmission, about 80)
 const uint8_t escRampTimeThirdGear = 75; // 75 for King Hauler
 const uint8_t escBrakeSteps = 30; // determines, how fast the ESC is able to brake down (20 - 30, 30 for King Hauler)
 const uint8_t escAccelerationSteps = 3; // determines, how fast the ESC is able to accelerate (2 - 3, 3 for King Hauler)
@@ -261,16 +259,16 @@ const boolean pwmSoundTrigger = true; // horn triggered by RC PWM signal instead
 // Gearbox parameters (select number of automatic gears in curves.h)-----------------------------------------------------
 const boolean automatic = false; // false = linear rpm curve, true = automatic transmission with torque converter is simulated (use it, if you don't have a real shifting transmission)
 const boolean doubleClutch = false; // do not activate it at the same time as automatic!
-const boolean shiftingAutoThrottle = true; // For Tamiya 3 speed transmission, throttle is altered for synchronizing, if "true"
+const boolean shiftingAutoThrottle = true; // For Tamiya 3 speed tansmission, throttle is altered for synchronizing, if "true"
 
 // Clutch parameters ---------------------------------------------------------------------------------------------------
-uint16_t clutchEngagingPoint = 90; // CEP. The "clutch" is engaging above this point = engine rpm sound in synch with ESC power (about 100)
+uint16_t clutchEngagingPoint = 0; // CEP. The "clutch" is engaging above this point = engine rpm sound in synch with ESC power
 
 // Shaker parameters (simulating engine vibrations) ---------------------------------------------------------------------
-const uint8_t shakerStart = 50; // Shaker power while engine start (max. 255, about 100, 50 with PETG weight)
-const uint8_t shakerIdle = 50; // Shaker power while idling (max. 255, about 49, 50 with PETG weight)
-const uint8_t shakerFullThrottle = 35; // Shaker power while full throttle (max. 255, about 42, 35 with PETG weight)
-const uint8_t shakerStop = 40; // Shaker power while engine stop (max. 255, about 60, 40 with PETG weight)
+const uint8_t shakerStart = 100; // Shaker power while engine start (max. 255, about 100)
+const uint8_t shakerIdle = 49; // Shaker power while idling (max. 255, about 49)
+const uint8_t shakerFullThrottle = 40; // Shaker power while full throttle (max. 255, about 40)
+const uint8_t shakerStop = 60; // Shaker power while engine stop (max. 255, about 60)
 
 // Engine parameters ----------------------------------------------------------------------------------------------------
 //Activate for "engine on off" functionality in combination with "Micro RC" Receiver from TheDIYGuy999. No Pulse Zero auto calibration in this case!!
@@ -280,5 +278,5 @@ const boolean engineManualOnOff = false;
 const uint32_t TOP_SPEED_MULTIPLIER = 3; // TSM. RPM multiplier: the bigger the number, the larger the rev range, 2 - 4 is a good place to start. ESP32 will crash, if > 5 @ 22'050Hz!
 
 // Engine mass simulation
-const int8_t acc = 2; // Acceleration step (2) 1 = slow for locomotive engine, 9 = fast for trophy truck
-const int8_t dec = 1; // Deceleration step (1) 1 = slow for locomotive engine, 5 = fast for trophy truck
+const int8_t acc = 5; // Acceleration step (2) 1 = slow for locomotive engine, 9 = fast for trophy truck
+const int8_t dec = 3; // Deceleration step (1) 1 = slow for locomotive engine, 5 = fast for trophy truck


### PR DESCRIPTION
Changes by me for FTX Kanyon:
Adjustments = DefenderV8 settings with changes to clutch engage 0 (My esc is sintant so sound matches car, only 1 gear on my car).

Gear detection always gear 1. PulseWidth used for gears is reused in LED section to be able to control the head, tail and rooflights from my CH5 pot on transmitter.

No backward bracking on my default ESC so removed the logic that set drive state 4, not just sets drive state 0 instead when accellerating after braking.

commented out SBUS (NOt sure why I did this)

Map CH2 pulse width to current spead rather than escPUlse Width as I don't use the inbuilt ESC other than it's logic for drivestate. This maps the CH2 throttle to the current speed. Matches my ESC better